### PR TITLE
enhancement: allow PVCs for node socket volume

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: [ main, develop ]
     tags: [ 'v*' ]
-    paths:
-      - 'src/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - '.github/workflows/build.yml'
-      - '.github/workflows/build-simple.yml'
     paths-ignore:
       - 'charts/**'
       - 'docs/**'

--- a/charts/cardano-node/README.md
+++ b/charts/cardano-node/README.md
@@ -190,9 +190,10 @@ forgeManager:
 
 ```yaml
 persistence:
-  enabled: true
-  size: 400Gi                  # Mainnet requires ~350GB+
-  storageClass: "fast-ssd"     # Use fast storage for best performance
+  ledger:
+      enabled: true
+      size: 400Gi                  # Mainnet requires ~350GB+
+      storageClass: "fast-ssd"     # Use fast storage for best performance
 ```
 
 #### Resource Configuration

--- a/charts/cardano-node/examples/mainnet-block-prod.yaml
+++ b/charts/cardano-node/examples/mainnet-block-prod.yaml
@@ -105,12 +105,15 @@ forgeManager:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  size: 400Gi  # Mainnet requires substantial storage
-  # storageClass: "fast-ssd"  # Use high-performance storage class for production
-  annotations:
-    # Example for AWS EBS volume encryption
-    # ebs.csi.aws.com/encrypted: "true"
+  ledger:
+    enabled: true
+    size: 400Gi  # Mainnet requires substantial storage
+    # storageClass: "fast-ssd"  # Use high-performance storage class for production
+    annotations:
+      # Example for AWS EBS volume encryption
+      # ebs.csi.aws.com/encrypted: "true"
+  socket:
+    enabled: false
 
 # ===========================================
 # RESOURCE CONFIGURATION (Production)

--- a/charts/cardano-node/examples/mainnet-relay-shared-socket.yaml
+++ b/charts/cardano-node/examples/mainnet-relay-shared-socket.yaml
@@ -1,6 +1,7 @@
 # Mainnet Relay Node - Production Ready Example
 # This is a complete, production-ready relay configuration for Cardano Mainnet
 # Optimized for high availability and performance
+# Socket can be shared by created PVC
 
 # ===========================================
 # BASIC CONFIGURATION
@@ -66,7 +67,7 @@ persistence:
     size: 400Gi  # Mainnet requires substantial storage
     # storageClass: "fast-ssd"  # Use high-performance storage class
   socket:
-    enabled: false
+    enabled: true
 
 # ===========================================
 # RESOURCE CONFIGURATION (Production)

--- a/charts/cardano-node/examples/testnet-preprod-block-prod.yaml
+++ b/charts/cardano-node/examples/testnet-preprod-block-prod.yaml
@@ -91,9 +91,12 @@ forgeManager:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  size: 35Gi  # Preprod network requires more storage than preview
-  # storageClass: ""  # Use default storage class
+  ledger:
+    enabled: true
+    size: 35Gi  # Preprod network requires more storage than preview
+    storageClass: ""  # Use default storage class
+  socket:
+    enabled: false
 
 # ===========================================
 # RESOURCE CONFIGURATION

--- a/charts/cardano-node/examples/testnet-preprod-relay.yaml
+++ b/charts/cardano-node/examples/testnet-preprod-relay.yaml
@@ -56,9 +56,12 @@ forgeManager:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  size: 35Gi  # Preprod network requires more storage than preview
-  # storageClass: ""  # Use default storage class
+  ledger:
+    enabled: true
+    size: 35Gi  # Preprod network requires more storage than preview
+    storageClass: ""  # Use default storage class
+  socket:
+    enabled: false
 
 # ===========================================
 # RESOURCE CONFIGURATION

--- a/charts/cardano-node/examples/testnet-preview-block-prod.yaml
+++ b/charts/cardano-node/examples/testnet-preview-block-prod.yaml
@@ -91,9 +91,12 @@ forgeManager:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  size: 25Gi  # Preview network requires less storage
-  # storageClass: ""  # Use default storage class
+  ledger:
+    enabled: true
+    size: 25Gi  # Preview network requires less storage
+    # storageClass: ""  # Use default storage class
+  socket:
+    enabled: false
 
 # ===========================================
 # RESOURCE CONFIGURATION

--- a/charts/cardano-node/examples/testnet-preview-relay.yaml
+++ b/charts/cardano-node/examples/testnet-preview-relay.yaml
@@ -57,9 +57,12 @@ forgeManager:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  size: 25Gi  # Preview network requires less storage
-  # storageClass: ""  # Use default storage class
+  ledger:
+    enabled: true
+    size: 25Gi  # Preview network requires less storage
+    # storageClass: ""  # Use default storage class
+  socket:
+    enabled: false
 
 # ===========================================
 # RESOURCE CONFIGURATION

--- a/charts/cardano-node/templates/statefulset.yaml
+++ b/charts/cardano-node/templates/statefulset.yaml
@@ -430,6 +430,25 @@ spec:
       # VOLUMES
       # ===========================================
       volumes:
+        # cardano-data: use an existing volume claim if provided, otherwise will create a volumeclaimtemplate
+        {{- if and .Values.persistence.ledger.enabled .Values.persistence.ledger.existingClaim }}
+        - name: cardano-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.ledger.existingClaim }}
+        {{- end }}
+
+        # socket-dir: use existing volume claim if provided, else create an emptydir 
+        # or create volumeclaimtemplate
+        {{- if and .Values.persistence.socket.enabled .Values.persistence.socket.existingClaim }}
+        - name: socket-dir
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.socket.existingClaim }}
+        {{- else if not .Values.persistence.socket.enabled }}
+        # EmptyDir for node socket
+        - name: socket-dir
+          emptyDir: {}
+        {{- end }}
+
         # ConfigMap for cardano-node config
         - name: cardano-config-src
           configMap:
@@ -437,10 +456,6 @@ spec:
         
         # EmptyDir for processed config
         - name: cardano-config
-          emptyDir: {}
-        
-        # EmptyDir for node socket
-        - name: socket-dir
           emptyDir: {}
         
         {{- if eq (include "cardano-node.forgeManagerEnabled" .) "true" }}
@@ -475,30 +490,7 @@ spec:
   # ===========================================
   # VOLUME CLAIM TEMPLATES
   # ===========================================
-  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  {{- if eq (include "cardano-node.requiresPVCs" .) "true" }}
   volumeClaimTemplates:
-    - metadata:
-        name: cardano-data
-        labels:
-          {{- include "cardano-node.labels" . | nindent 10 }}
-        {{- with .Values.persistence.annotations }}
-        annotations:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-      spec:
-        accessModes:
-          - {{ .Values.persistence.accessMode | quote }}
-        {{- if .Values.persistence.storageClass }}
-        {{- if (eq "-" .Values.persistence.storageClass) }}
-        storageClassName: ""
-        {{- else }}
-        storageClassName: {{ .Values.persistence.storageClass | quote }}
-        {{- end }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.size | quote }}
-  {{- else if .Values.persistence.existingClaim }}
-  # Using existing PVC
-  # Note: This requires manual PVC creation before chart installation
+  {{ include "cardano-node.volumeClaimTemplates" . | nindent 2 }}
   {{- end }}

--- a/charts/cardano-node/values.yaml
+++ b/charts/cardano-node/values.yaml
@@ -399,14 +399,27 @@ submitApi:
 # STORAGE CONFIGURATION
 # ===========================================
 persistence:
-  enabled: true
-  storageClass: ""  # Use default storage class if empty
-  accessMode: ReadWriteOnce
-  size: 200Gi  # Increase for mainnet (400Gi+ recommended)
-  annotations: {}
-  
-  # Existing PVC (if you want to use an existing volume)
-  existingClaim: ""
+  # Cardano ledger storage
+  ledger:
+    enabled: true
+    storageClass: ""  # Use default storage class if empty
+    accessMode: ReadWriteOnce
+    size: 200Gi  # Increase for mainnet (400Gi+ recommended)
+    annotations: {}
+    
+    # Existing PVC (if you want to use an existing volume)
+    existingClaim: ""
+  # Optional: create a PVC for the IPC socket if needed by
+  # external applications not part of this release
+  socket:
+    enabled: false # default: disabled; use emptyDir instead
+    storageClass: ""  # Use default storage class if empty
+    accessMode: ReadWriteOnce
+    size: 10Mi
+    annotations: {}
+    
+    # Existing PVC (if you want to use an existing volume)
+    existingClaim: ""
 
 # ===========================================
 # RESOURCE CONFIGURATION


### PR DESCRIPTION
This change introduces the ability to specify a PVC (either for a volumeclaimtemplate, or an existing claim) to be used for the ipc socket. This is useful if the operator wants to share the socket among other containers, instead of spinning up an entirely new pod which can be resource-heavy.

The fallback is to use an emptyDir, as was done before.